### PR TITLE
feat: flag blacklisted LFG groups

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -283,6 +283,28 @@ function AGS:SetOverlay(frame, enabled)
   end
 end
 
+function AGS:SetGroupNamePrefix(row, enabled)
+  if not row then return end
+  local label = row.Name or row.GroupName or (row.DataDisplay and row.DataDisplay.Name)
+  if not label or not label.GetText or not label.SetText then return end
+  if enabled then
+    if not row.__AegisOriginalName then
+      row.__AegisOriginalName = label:GetText()
+    end
+    if not row.__AegisPrefixed then
+      label:SetText("|cffff0000BLACKLIST|r " .. (row.__AegisOriginalName or ""))
+      row.__AegisPrefixed = true
+    end
+  else
+    if row.__AegisPrefixed and row.__AegisOriginalName then
+      label:SetText(row.__AegisOriginalName)
+    else
+      row.__AegisOriginalName = label:GetText()
+    end
+    row.__AegisPrefixed = nil
+  end
+end
+
 function AGS:RefreshLFGHighlights()
   if not self.db or not self.db.profile.settings.enableLFGHighlight then return end
 
@@ -340,6 +362,7 @@ function AGS:RefreshLFGHighlights()
         end
       end
       self:SetOverlay(row, isBL)
+      self:SetGroupNamePrefix(row, isBL)
     end)
   end
 end

--- a/Widgets.lua
+++ b/Widgets.lua
@@ -96,6 +96,7 @@ local function buildTopControls(container, scope)
                 ADDON:AddPlayer(name, ebReason:GetText(), { type = ddType:GetValue(), category = ddCat:GetValue() })
                 -- Fire both for compatibility with old/new event names
                 container:Fire("Aegis_Refresh")
+                container:Fire("AegisRefresh")
             end
         end)
         wrap:AddChild(btn)
@@ -113,6 +114,7 @@ local function buildTopControls(container, scope)
                 local realm = ebRealm:GetText(); if realm == "" then realm = nil end
                 ADDON:AddGuild(g, realm, ebReason:GetText(), { type = ddType:GetValue(), category = ddCat:GetValue() })
                 container:Fire("Aegis_Refresh")
+                container:Fire("AegisRefresh")
             end
         end)
         wrap:AddChild(btn)
@@ -128,6 +130,7 @@ local function buildTopControls(container, scope)
             if r and r ~= "" then
                 ADDON:AddRealm(r, ebReason:GetText(), { type = ddType:GetValue(), category = ddCat:GetValue() })
                 container:Fire("Aegis_Refresh")
+                container:Fire("AegisRefresh")
             end
         end)
         wrap:AddChild(btn)


### PR DESCRIPTION
## Summary
- Highlight LFG listings led by blacklisted players with a red 'BLACKLIST' prefix
- Refresh tables after adding players, guilds, or realms

## Testing
- `luac -p Core.lua Widgets.lua` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a17989250c832f9d7c5de390e0f12f